### PR TITLE
Python3 compatibility

### DIFF
--- a/examples/all_pairs.py
+++ b/examples/all_pairs.py
@@ -38,9 +38,9 @@ public class HelloUniverse {
     }
 }
 """]
-    print all_pairs(catalogue)
-    print all_pairs(catalogue, parallel=True)
-    print all_pairs(catalogue, distance=distances.kolmogorov)
+    print(all_pairs(catalogue))
+    print(all_pairs(catalogue, parallel=True))
+    print(all_pairs(catalogue, distance=distances.kolmogorov))
 
 # Example code for loading a pickle file of submissions
 

--- a/examples/clustering.py
+++ b/examples/clustering.py
@@ -17,9 +17,13 @@ the correct matplotlib backend.
 
 from ripoff import all_pairs, distances
 from ripoff.clustering import cluster
-import urllib2
 import hcluster
 import pylab
+
+try:
+    import urllib.request as liburl
+except ImportError:
+    import urllib2 as liburl
 
 # some famous German literature
 urls = [("http://www.gutenberg.org/files/21000/21000-0.txt",      "Faust 1"),
@@ -40,8 +44,8 @@ catalogue = []
 
 for url, name in urls:
     headers = {'User-Agent': 'Mozilla/5.0'}
-    req = urllib2.Request(url, None, headers)
-    catalogue.append(urllib2.urlopen(req).read())
+    req = liburl.Request(url, None, headers)
+    catalogue.append(liburl.urlopen(req).read())
 
 # calc similarity matrix
 M = all_pairs(catalogue,

--- a/ripoff/clustering.py
+++ b/ripoff/clustering.py
@@ -12,10 +12,7 @@ I.e. you have to do something like:
 @author: moschlar
 '''
 
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from io import StringIO
 
 import pylab
 import hcluster
@@ -26,7 +23,7 @@ def cluster(M, method='complete'):
 
 
 def dendrogram(M, method='complete', title='complete linkage clustering', **kw):
-    s = StringIO.StringIO()
+    s = StringIO()
     pylab.figure()
     if title:
         pylab.title(title)

--- a/ripoff/clustering.py
+++ b/ripoff/clustering.py
@@ -14,15 +14,16 @@ I.e. you have to do something like:
 
 from io import StringIO
 
-import pylab
 import hcluster
-
 
 def cluster(M, method='complete'):
     return hcluster.linkage(hcluster.squareform(M), method=method)
 
 
 def dendrogram(M, method='complete', title='complete linkage clustering', **kw):
+
+    import pylab
+    
     s = StringIO()
     pylab.figure()
     if title:

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
         "Topic :: Software Development :: Libraries",
         "License :: OSI Approved :: BSD License",
     ],
-    install_requires=['numpy', 'hcluster', 'matplotlib'],
+    install_requires=['numpy', 'dedupe-hcluster', 'matplotlib'],
 )


### PR DESCRIPTION
Tested on Python-3.4.3 and 2.7.10 on OSX.
- Python3-compatible use of `StringIO`, `urllib` and `print`
- replaced `hcluster` by  `dedupe-hcluster` which is Py3 compatible
